### PR TITLE
Update RFXComLighting4Message.java

### DIFF
--- a/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4Message.java
+++ b/bundles/binding/org.openhab.binding.rfxcom/src/main/java/org/openhab/binding/rfxcom/internal/messages/RFXComLighting4Message.java
@@ -232,7 +232,13 @@ public class RFXComLighting4Message extends RFXComBaseMessage {
 						+ " to Command");
 			}
 			break;
-
+		case NUMBER:
+                	if (type instanceof DecimalType) {
+                		commandId = ((DecimalType) type).intValue();
+                	} else {
+                    	throw new RFXComException("Can't convert " + type + " to Command");
+                	}
+                	break;
 		default:
 			throw new RFXComException("Can't convert " + type + " to "
 					+ valueSelector);


### PR DESCRIPTION
Adds Number Type to Lighting4 Outputs to allow Aoke 4 Port Relay to work.
Usage:
In Items:   Number RFXTest { rfxcom=">123456.550:LIGHTING4.PT2262:Number" }
where 123456 is your item's address and 550 is the pulse length
In Rules:  RFXTest.sendCommand("15")
where the number in quotes is what is sent to the relay. 15 is all 4 relays on. 0 is all 4 relays off,
